### PR TITLE
Resolves #1, Resolution Errors caused by bad memory handling

### DIFF
--- a/data_write.c
+++ b/data_write.c
@@ -12,9 +12,9 @@ void data_write(
         ){
     unsigned int x, y;
 
-    for (int j = 1; j < i; j++){
+    for (unsigned int j = 1; j < i; j++){
         x = mapBuff[2*j];
         y = mapBuff[2*j+1];
-        data[x_resolution * y + x] = data[x_resolution * y + x] + 1;
+        data[x_resolution*y+x] += 1;
     }
 }

--- a/freq_map.c
+++ b/freq_map.c
@@ -11,9 +11,10 @@ void freq_map(
         unsigned int * data
         ){
     const double half_x = x_resolution / 2.0, half_y = y_resolution / 2.0, scalar = 4.0 / y_resolution;
+
     unsigned int x, y;
-    int conv_test_var = 0;
-    double a_old = 0, b_old = 0;
+    unsigned int conv_test_var = 0;
+    double a_old = 0.0, b_old = 0.0;
 
     double x0, y0;
     double a, b;
@@ -56,14 +57,11 @@ void freq_map(
                a2 = a * a;
                b2 = b * b;
 
-               mapBuff[2*i]   = (int) rint(a / scalar + half_x);
-               mapBuff[2*i+1] = (int) rint(b / scalar + half_y);
-
                if(a2 + b2 > 4.0) break;
-
+               mapBuff[2*i]   = (unsigned int) rint((double) a / (double) scalar + (double) half_x);
+               mapBuff[2*i+1] = (unsigned int) rint((double) b / (double) scalar + (double) half_y);
                i++;
             }
-
             if(i == escape_limit) continue;
             data_write(mapBuff, data, i, x_resolution);
         }

--- a/freq_map.c
+++ b/freq_map.c
@@ -58,8 +58,8 @@ void freq_map(
                b2 = b * b;
 
                if(a2 + b2 > 4.0) break;
-               mapBuff[2*i]   = (unsigned int) rint((double) a / (double) scalar + (double) half_x);
-               mapBuff[2*i+1] = (unsigned int) rint((double) b / (double) scalar + (double) half_y);
+               mapBuff[2*i]   = (unsigned int) ((double) a / (double) scalar + (double) half_x);
+               mapBuff[2*i+1] = (unsigned int) ((double) b / (double) scalar + (double) half_y);
                i++;
             }
             if(i == escape_limit) continue;

--- a/gen_ppm.c
+++ b/gen_ppm.c
@@ -26,9 +26,9 @@ void gen_ppm(
     fprintf(image, "P6\n%s\n%d\n%d\n%d\n", com, x_resolution, y_resolution, 255);
     for (unsigned int y = 0; y < y_resolution; y++){
         for (unsigned int x = 0; x < x_resolution; x++){
-            color[0] = sqrt((double) data[x_resolution * y + x] / (double) max) * 255;
-            color[1] = sqrt((double) data[x_resolution * y + x] / (double) max) * 255;
-            color[2] = sqrt((double) data[x_resolution * y + x] / (double) max) * 255;
+            color[0] = ((double) data[x_resolution * y + x] / (double) max) * 255;
+            color[1] = ((double) data[x_resolution * y + x] / (double) max) * 255;
+            color[2] = ((double) data[x_resolution * y + x] / (double) max) * 255;
             fwrite(color, 1, 3, image);
         }
     }

--- a/main.c
+++ b/main.c
@@ -3,23 +3,27 @@
 #include "freq_map.h"
 #include "gen_ppm.h"
 #include "importance_map.h"
+#include "progress_bar.h"
 
 int main() {
+    /* Generate Progress Bar Lower Layer */
+    progress_bar_init();
+
     /* Define info needed for writing a PPM image. Will later be moved when
      * support for other formats is added. */
     char * name = "test.ppm";
     char * com = "# ";
 
-    unsigned int x_resolution = 1920;
-    unsigned int y_resolution = 1920;
-    //y_resolution += (y_resolution % 2 == 0);
-    unsigned int escape_limit = 512;
+    unsigned int x_resolution = 320;
+    unsigned int y_resolution = 222;
+    y_resolution += (y_resolution % 2 == 0);
+    unsigned int escape_limit = 8192*32;
 
 
     /* Define an output array. Needs to be dynamically allocated due to stack
      * memory size constraints. */
     unsigned int * data;
-    data = (unsigned int *) malloc(sizeof(unsigned int) * x_resolution * y_resolution);
+    data = (unsigned int *) calloc(x_resolution*y_resolution,sizeof(unsigned int));
 
 
     /* Calculate various forms of fractals. Outputs to inputted Data.

--- a/main.c
+++ b/main.c
@@ -14,10 +14,10 @@ int main() {
     char * name = "test.ppm";
     char * com = "# ";
 
-    unsigned int x_resolution = 320;
-    unsigned int y_resolution = 222;
+    unsigned int x_resolution = 2560;
+    unsigned int y_resolution = 2560;
     y_resolution += (y_resolution % 2 == 0);
-    unsigned int escape_limit = 8192*32;
+    unsigned int escape_limit = 8192;
 
 
     /* Define an output array. Needs to be dynamically allocated due to stack


### PR DESCRIPTION
General typing improvements, marginal speed improvements, and fixes faulty renders at low resolutions. Another error was found for renders at high resolutions. The increased precision, then later rounding of values, was inputting out-of-bounds to the storage array. Removing the rounding and replacing with truncation fixed the problem.

Notes for if a similar issue is encountered in the future:
Try `calloc` and check inputs that source in long equations.